### PR TITLE
Windows support

### DIFF
--- a/withenv/config.py
+++ b/withenv/config.py
@@ -1,4 +1,6 @@
 import os
+import yaml
+
 
 CONFIG_FILE = '.werc'
 

--- a/withenv/config.py
+++ b/withenv/config.py
@@ -1,6 +1,4 @@
 import os
-import yaml
-
 
 CONFIG_FILE = '.werc'
 
@@ -11,7 +9,7 @@ def find_config_file(start=None, filename=CONFIG_FILE):
     if os.path.exists(conf):
         return conf
 
-    if start == '/':
+    if start == os.path.abspath(os.sep):
         return None
 
     parent = os.path.normpath(os.path.abspath(os.path.join(start, '..')))


### PR DESCRIPTION
Hi,

This is the only change required to make `withenv` work on Windows, would you consider merging it?
It prevents an infinite recursion when looking for `.werc` files.

Thanks,
Alex
